### PR TITLE
Escape square brackets in filename for subtitles

### DIFF
--- a/mpv-gif.lua
+++ b/mpv-gif.lua
@@ -79,6 +79,8 @@ function make_gif_internal(burn_subtitles)
         s = string.gsub(s, '"', '"\\""')
         s = string.gsub(s, ":", [[\\:]])
         s = string.gsub(s, "'", [[\\']])
+        s = string.gsub(s, "%[", "\\%[")
+        s = string.gsub(s, "%]", "\\%]")
         return s
     end
 


### PR DESCRIPTION
I had problems with generating gifs with subtitles, and it turns out the file I was playing had square brackets in the name like "[" and "]". These needed to be escaped for ffmpeg to parse it as the subtitles argument properly.

Not sure if this is the best way to fix or if there are any other special characters that could mess this parameter up, but this at least fixes a common occurrence of fansub groups listed in brackets.

For reference, this was also tested on a Windows machine.